### PR TITLE
Add find_contact_by_name tool to support rich contact retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An Osaurus plugin for managing Contacts on macOS.
 
 - `get_all_numbers`: Get all contacts and their phone numbers
 - `find_number`: Find phone numbers for a contact by name
+- `find_contact_by_name`: Find full contact details (phone, email) for a contact by name
 - `find_contact_by_phone`: Find a contact name by their phone number
 
 ## Development

--- a/Sources/osaurus_contacts/ContactsManager.swift
+++ b/Sources/osaurus_contacts/ContactsManager.swift
@@ -1,8 +1,25 @@
 import Contacts
 import Foundation
 
+struct LabeledValue: Codable {
+  let label: String
+  let value: String
+}
+
+struct ContactInfo: Codable {
+  let name: String
+  let phoneNumbers: [LabeledValue]
+  let emails: [LabeledValue]
+}
+
 class ContactsManager {
   private let store = CNContactStore()
+
+  // Helper to normalize labels (e.g., "_$!<Home>!$_" -> "home")
+  private func normalizeLabel(_ label: String?) -> String {
+    guard let label = label else { return "other" }
+    return CNLabeledValue<NSString>.localizedString(forLabel: label).lowercased()
+  }
 
   // Helper to ensure we have access
   private func ensureAccess() throws {
@@ -72,45 +89,70 @@ class ContactsManager {
   }
 
   func findNumber(name: String) throws -> [String] {
+    let contacts = try findContactByName(name: name)
+    return contacts.flatMap { $0.phoneNumbers.map { $0.value } }
+  }
+
+  func findContactByName(name: String) throws -> [ContactInfo] {
     try ensureAccess()
 
-    // Try exact match first using predicate (fast)
-    let predicate = CNContact.predicateForContacts(matchingName: name)
-    let keys = [CNContactPhoneNumbersKey] as [CNKeyDescriptor]
+    let keys = [
+      CNContactGivenNameKey, CNContactFamilyNameKey, CNContactPhoneNumbersKey,
+      CNContactEmailAddressesKey,
+    ] as [CNKeyDescriptor]
 
-    var allPhones: [String] = []
+    // exact match using predicate
+    let predicate = CNContact.predicateForContacts(matchingName: name)
+    var results: [ContactInfo] = []
 
     do {
       let contacts = try store.unifiedContacts(matching: predicate, keysToFetch: keys)
       for contact in contacts {
-        allPhones.append(contentsOf: contact.phoneNumbers.map { $0.value.stringValue })
+        let fullName = [contact.givenName, contact.familyName].filter { !$0.isEmpty }.joined(
+          separator: " ")
+        results.append(
+          ContactInfo(
+            name: fullName,
+            phoneNumbers: contact.phoneNumbers.map {
+              LabeledValue(label: self.normalizeLabel($0.label), value: $0.value.stringValue)
+            },
+            emails: contact.emailAddresses.map {
+              LabeledValue(label: self.normalizeLabel($0.label), value: $0.value as String)
+            }
+          ))
       }
     } catch {
-      // Ignore error and fall back to fuzzy search
+      // ignore error and fall back
     }
 
-    if !allPhones.isEmpty {
-      return allPhones
+    if !results.isEmpty {
+      return results
     }
 
-    // Fallback: Fuzzy search (iterate all)
-    let allContacts = try getAllNumbers(limit: 5000)
-
+    // fuzzy search (iterate all)
     let searchName = name.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    let request = CNContactFetchRequest(keysToFetch: keys)
 
-    // Strategy 1: Exact match case-insensitive
-    if let match = allContacts.keys.first(where: { $0.lowercased() == searchName }) {
-      return allContacts[match] ?? []
+    try store.enumerateContacts(with: request) { contact, _ in
+      let fullName = [contact.givenName, contact.familyName].filter { !$0.isEmpty }.joined(
+        separator: " ")
+      let lowerFullName = fullName.lowercased()
+
+      if lowerFullName.contains(searchName) || searchName.contains(lowerFullName) {
+        results.append(
+          ContactInfo(
+            name: fullName,
+            phoneNumbers: contact.phoneNumbers.map {
+              LabeledValue(label: self.normalizeLabel($0.label), value: $0.value.stringValue)
+            },
+            emails: contact.emailAddresses.map {
+              LabeledValue(label: self.normalizeLabel($0.label), value: $0.value as String)
+            }
+          ))
+      }
     }
 
-    // Strategy 2: Contains
-    if let match = allContacts.keys.first(where: {
-      $0.lowercased().contains(searchName) || searchName.contains($0.lowercased())
-    }) {
-      return allContacts[match] ?? []
-    }
-
-    return []
+    return results
   }
 
   func findContactByPhone(phone: String) throws -> String? {

--- a/Sources/osaurus_contacts/Plugin.swift
+++ b/Sources/osaurus_contacts/Plugin.swift
@@ -11,6 +11,7 @@ protocol Tool {
 extension GetAllNumbersTool: Tool {}
 extension FindNumberTool: Tool {}
 extension FindContactByPhoneTool: Tool {}
+extension FindContactByNameTool: Tool {}
 
 // MARK: - C ABI surface
 
@@ -46,6 +47,7 @@ private class PluginContext {
       GetAllNumbersTool(manager: manager),
       FindNumberTool(manager: manager),
       FindContactByPhoneTool(manager: manager),
+      FindContactByNameTool(manager: manager),
     ]
     return Dictionary(uniqueKeysWithValues: list.map { ($0.name, $0) })
   }()

--- a/Sources/osaurus_contacts/Tools.swift
+++ b/Sources/osaurus_contacts/Tools.swift
@@ -88,3 +88,33 @@ struct FindContactByPhoneTool {
     }
   }
 }
+
+struct FindContactByNameTool {
+  let name = "find_contact_by_name"
+  let description = "Find full contact details (phone, email) for a contact by name"
+  let parameters =
+    "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\",\"description\":\"Name to search for\"}},\"required\":[\"name\"]}"
+
+  let manager: ContactsManager
+
+  func run(args: String) -> String {
+    struct Args: Decodable {
+      let name: String
+    }
+
+    guard let data = args.data(using: .utf8),
+      let input = try? JSONDecoder().decode(Args.self, from: data)
+    else {
+      return "{\"error\": \"Invalid arguments\"}"
+    }
+
+    do {
+      let contacts = try manager.findContactByName(name: input.name)
+      let data = try JSONEncoder().encode(contacts)
+      return String(data: data, encoding: .utf8) ?? "[]"
+    } catch {
+      return "{\"error\": \"\(error.localizedDescription)\"}"
+    }
+  }
+}
+


### PR DESCRIPTION
Addresses #2 from this repo & the corresponding [issue](https://github.com/osaurus-ai/osaurus/issues/707) in the main repo.

- Added `find_contact_by_name` which returns an array of `ContactInfo` objects containing full names, labeled phone numbers, and labeled email addresses.
- Implemented a `LabeledValue` structure to distinguish between "home", "work", and "mobile" entries as requested